### PR TITLE
Fixed decline_trade not working

### DIFF
--- a/src/authenticator.py
+++ b/src/authenticator.py
@@ -203,7 +203,7 @@ class Authenticator:
         self.__current_account = TAG
         self.__current_session = requests.session()
         
-        return self.__ExecuteSequence(METHOD='DECLINE', INIT_DATA={'USER_ID': self._accs[self.__current_account]['USER_ID'],'TRADE_ID': TRADE_ID})
+        return self.__ExecuteSequence(METHOD='DECLINE', INIT_DATA={'USER_ID': self._accs[self.__current_account]['USER_ID'],'TRADE_ID': TRADE_ID, 'POSTDATA': {}})
 
     @Validate.validate_tag   
     @Validate.validate_types
@@ -475,7 +475,7 @@ class AuthenticatorAsync:
         self.__current_account = TAG
         self.__current_session = requests.session()
         
-        return await self.__ExecuteSequence(METHOD='DECLINE', INIT_DATA={'USER_ID': self._accs[self.__current_account]['USER_ID'],'TRADE_ID': TRADE_ID})
+        return await self.__ExecuteSequence(METHOD='DECLINE', INIT_DATA={'USER_ID': self._accs[self.__current_account]['USER_ID'],'TRADE_ID': TRADE_ID, 'POSTDATA': {}})
 
     @Validate.validate_tag   
     @Validate.validate_types

--- a/src/config.py
+++ b/src/config.py
@@ -6,7 +6,8 @@ class Config:
         'CHALLENGEID':
             {
                 'SEND': 'https://trades.roblox.com/v1/trades/send',
-                'ACCEPT': 'https://trades.roblox.com/v1/trades/$TRADE_ID$/accept'
+                'ACCEPT': 'https://trades.roblox.com/v1/trades/$TRADE_ID$/accept',
+                'DECLINE': 'https://trades.roblox.com/v1/trades/$TRADE_ID$/decline'
             },
         'GROUP_CHALLENGEID':
             {


### PR DESCRIPTION
`t.decline_trade` does not work. 
This is because of two things

First thing:

 `decline_trade` function doesn't pass `'POSTDATA': {}` to `__ExecuteSequence`.

Second thing:

`config.Config.URLCONFIG` was missing a key and value for `DECLINE` all together. After I added `https://trades.roblox.com/v1/trades/$TRADE_ID$/decline`, declining trades finally worked.

I have opened a pull request on your repo with these changes.